### PR TITLE
Fix `impl State for PendingReview`

### DIFF
--- a/second-edition/src/ch17-03-oo-design-patterns.md
+++ b/second-edition/src/ch17-03-oo-design-patterns.md
@@ -317,9 +317,9 @@ impl State for Draft {
 struct PendingReview {}
 
 impl State for PendingReview {
-#     fn request_review(self: Box<Self>) -> Box<State> {
-#         Box::new(PendingReview {})
-#     }
+#    fn request_review(self: Box<Self>) -> Box<State> {
+#        self
+#    }
 #
     // ...snip...
     fn approve(self: Box<Self>) -> Box<State> {


### PR DESCRIPTION
Fix `impl State for PendingReview` to match the previous `impl`

### Second edition

I think this still qualifies, in case it doesn't... well, sorry for the noise. 